### PR TITLE
Show both state panes in the VizGUI

### DIFF
--- a/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/AlloyLanguageServer.java
+++ b/org.alloytools.alloy.application/src/main/java/edu/mit/csail/sdg/alloy4whole/AlloyLanguageServer.java
@@ -1444,7 +1444,7 @@ class AlloyTextDocumentService implements TextDocumentService, WorkspaceService,
 			// from SimpleGui
 			// VizGUI viz = new VizGUI(false, "", windowmenu2, enumerator, evaluator);
 			if(viz == null)
-				viz = new VizGUI(false, "", null, enumerator, evaluator, 1);
+				viz = new VizGUI(false, "", null, enumerator, evaluator, 2);
 			viz.loadXML(Util.canon(arg.substring(5)), false);
 		}
 	}


### PR DESCRIPTION
Currently, the Language server invocation of the VizGUI differs from that in the
main program because it currently only shows the "current" state in temporal models,
rather than showing both the "current" and the "next" state.

Seeing the "next" state is important because it allows you to see what you're
switching between when you use the "Next Fork" feature, as it is the
"next" state that you are causing to differ when you click this. 

Changing the `VizGUI` invocation from `panes=1` to `panes=2` makes
the invocation match the one used by the main Alloy program.